### PR TITLE
Information about individual JSON schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,12 @@ A full JSON schema for the `dotpkg.json` manifests can be found [here](dotpkg.sc
   ]
 }
 ```
+
+Alternatively, you can specify the schema individually in each `dotpkg.json`:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/fwcd/dotpkg/main/dotpkg.schema.json"
+  // ...
+}
+```


### PR DESCRIPTION
This PR adds information about how to specify an individual JSON schema via `$schema` in each `dotpkg.json` to the README. 